### PR TITLE
Featute/eval funktionality for creation dialog

### DIFF
--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -71,6 +71,7 @@ const getDerivedStateFromProps = (props, state) => {
         }
     };
 }
+console.log('hi11');
 
 const preprocessViewConfiguration = (state, path = [], viewConfiguration, originalViewConfiguration) => {
     const currentLevel = path.length === 0 ? viewConfiguration : $get(path, viewConfiguration);
@@ -83,7 +84,7 @@ const preprocessViewConfiguration = (state, path = [], viewConfiguration, origin
         if (propertyValue !== null && typeof propertyValue === 'object') {
             viewConfiguration = preprocessViewConfiguration(state, newPath, viewConfiguration, originalViewConfiguration);
         } else if (typeof originalPropertyValue === 'string' && originalPropertyValue.indexOf('ClientEval:') === 0) {
-            const {node, transient} = state; // eslint-disable-line
+            const {node} = state;
             try {
                 // eslint-disable-next-line no-new-func
                 const evaluatedValue = new Function('node', 'return ' + originalPropertyValue.replace('ClientEval:', ''))(node);
@@ -94,9 +95,6 @@ const preprocessViewConfiguration = (state, path = [], viewConfiguration, origin
                             return $set(newPath, evaluatedValue, draft);
                         }
                     );
-                    // if (viewConfiguration.elements[newPath[1]].ui.hidden) {
-                    //     transient[newPath[1]].value = '';
-                    // }
                 }
             } catch (e) {
                 console.warn('An error occurred while trying to evaluate "' + originalPropertyValue + '"\n', e);

--- a/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
+++ b/packages/neos-ui/src/Containers/Modals/NodeCreationDialog/index.js
@@ -71,7 +71,6 @@ const getDerivedStateFromProps = (props, state) => {
         }
     };
 }
-console.log('hi11');
 
 const preprocessViewConfiguration = (state, path = [], viewConfiguration, originalViewConfiguration) => {
     const currentLevel = path.length === 0 ? viewConfiguration : $get(path, viewConfiguration);


### PR DESCRIPTION
What I did

I bring some ClientEval functionality into nodeCreationDialog.

How I did it

Because in the nodeCreationDialog step, the node doesn't create yet I build an artificial Node Object in the State of nodeCreationDialog Modal, which helps us to get the value of each node.properties and then I used the preprocessViewConfiguration function that's almost similar to the function that we used in Inspector, to set the right value and configuration in nodeCreationDialog.

How to verify it

I upload a video to help to better understand.


https://user-images.githubusercontent.com/52664771/216025357-0b330b51-fc09-4cbe-8cb7-7a12f8628de9.mov

